### PR TITLE
Add configurable model parameters and resilient ChatGPT client

### DIFF
--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -12,6 +12,8 @@ class Settings(BaseModel):
     """Runtime settings for the quiz automation tool."""
 
     openai_api_key: str = ""
+    openai_model: str = "gpt-4o-mini-high"
+    openai_temperature: float = 0.0
     poll_interval: float = 0.5
 
 

--- a/tests/test_chatgpt_client.py
+++ b/tests/test_chatgpt_client.py
@@ -24,3 +24,58 @@ def patch_openai(monkeypatch):
 def test_chatgpt_client_parsing():
     client = ChatGPTClient()
     assert client.ask("question") == "A"
+
+
+def test_chatgpt_client_malformed_response(monkeypatch):
+    class BadResponses:
+        def create(self, **_: str):  # noqa: D401
+            return SimpleNamespace(
+                output=[SimpleNamespace(content=[SimpleNamespace(text="not json")])]
+            )
+
+    class BadClient:
+        responses = BadResponses()
+
+    monkeypatch.setattr(
+        "quiz_automation.chatgpt_client.OpenAI", lambda api_key: BadClient()
+    )
+    client = ChatGPTClient()
+    assert client.ask("question") == "Error: malformed response"
+
+
+def test_chatgpt_client_retry(monkeypatch):
+    class FlakyResponses:
+        def __init__(self):
+            self.calls = 0
+
+        def create(self, **_: str):  # noqa: D401
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("boom")
+            text = json.dumps({"answer": "A"})
+            return SimpleNamespace(
+                output=[SimpleNamespace(content=[SimpleNamespace(text=text)])]
+            )
+
+    flaky = FlakyResponses()
+
+    class FlakyClient:
+        responses = flaky
+
+    monkeypatch.setattr(
+        "quiz_automation.chatgpt_client.OpenAI", lambda api_key: FlakyClient()
+    )
+
+    sleeps = []
+
+    def fake_sleep(seconds: float) -> None:  # pragma: no cover - helper
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(
+        "quiz_automation.chatgpt_client.time.sleep", fake_sleep
+    )
+
+    client = ChatGPTClient()
+    assert client.ask("question") == "A"
+    assert flaky.calls == 2
+    assert sleeps == [1.0]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,3 +3,5 @@ from quiz_automation.config import settings
 
 def test_config_defaults():
     assert settings.poll_interval == 0.5
+    assert settings.openai_model == "gpt-4o-mini-high"
+    assert settings.openai_temperature == 0.0


### PR DESCRIPTION
## Summary
- add model name and temperature to runtime settings
- wrap ChatGPT calls in try/except and implement retry with backoff
- test malformed responses and retry logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b72fdb94c832887f209c0300a1ccd