### PR TITLE
Add context manager support to QuizLogger

### DIFF
--- a/quiz_automation/logger.py
+++ b/quiz_automation/logger.py
@@ -31,3 +31,13 @@ class QuizLogger:
             (ts, question, answer, x, y),
         )
         self.conn.commit()
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        self.conn.close()
+
+    def __enter__(self) -> "QuizLogger":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,13 +1,22 @@
 from pathlib import Path
 import sqlite3
+import pytest
 
 from quiz_automation.logger import QuizLogger
 
 
 def test_logger_inserts(tmp_path: Path):
     db_path = tmp_path / "events.db"
-    logger = QuizLogger(db_path)
-    logger.log("ts", "question", "A", 1, 2)
+    with QuizLogger(db_path) as logger:
+        logger.log("ts", "question", "A", 1, 2)
     conn = sqlite3.connect(db_path)
     row = conn.execute("SELECT * FROM events").fetchone()
     assert row == ("ts", "question", "A", 1, 2)
+
+
+def test_logger_closes_connection(tmp_path: Path):
+    db_path = tmp_path / "events.db"
+    with QuizLogger(db_path) as logger:
+        logger.log("ts", "question", "A", 1, 2)
+    with pytest.raises(sqlite3.ProgrammingError):
+        logger.conn.execute("SELECT 1")


### PR DESCRIPTION
## Summary
- add context manager methods and `close()` to `QuizLogger` for connection lifecycle management
- use `with QuizLogger(...)` in tests
- test that the connection is closed after leaving the context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b72fe4ddc8328b2789898266b4396