### PR TITLE
Support variable quiz option counts and validate answers

### DIFF
--- a/quiz_automation/clicker.py
+++ b/quiz_automation/clicker.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional
 
 import pyautogui
 
@@ -10,14 +10,38 @@ import pyautogui
 LETTER_OFFSETS: Dict[str, int] = {"A": 0, "B": 1, "C": 2, "D": 3}
 
 
-def click_answer(letter: str, region: Tuple[int, int, int, int]) -> Tuple[int, int]:
+def _generate_offsets(num_options: int) -> Dict[str, int]:
+    """Generate a mapping of letter to row index."""
+    return {chr(ord("A") + i): i for i in range(num_options)}
+
+
+def click_answer(
+    letter: str,
+    region: Tuple[int, int, int, int],
+    *,
+    offsets_map: Optional[Dict[str, int]] = None,
+    num_options: Optional[int] = None,
+) -> Tuple[int, int]:
     """Click within the region based on answer letter.
 
     Returns the coordinates clicked so tests can verify them.
+
+    Either ``offsets_map`` or ``num_options`` can be supplied to support
+    quizzes with differing numbers of options.
     """
+    offsets = offsets_map
+    if offsets is None:
+        if num_options is None:
+            offsets = LETTER_OFFSETS
+        else:
+            offsets = _generate_offsets(num_options)
+
+    if letter not in offsets:
+        raise ValueError(f"Unknown letter: {letter}")
+
     left, top, width, height = region
-    row_height = height // 4
-    y = top + LETTER_OFFSETS[letter] * row_height + row_height // 2
+    row_height = height // len(offsets)
+    y = top + offsets[letter] * row_height + row_height // 2
     x = left + width // 2
     pyautogui.click(x, y)
     return x, y

--- a/tests/test_clicker.py
+++ b/tests/test_clicker.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from quiz_automation.clicker import click_answer
 
 
@@ -9,3 +11,19 @@ def test_click_answer_coordinates():
         x, y = click_answer("C", region)
         mock_click.assert_called_once_with(x, y)
         assert (x, y) == (50, 250)
+
+
+def test_click_answer_invalid_letter():
+    region = (0, 0, 100, 400)
+    with patch("quiz_automation.clicker.pyautogui.click") as mock_click:
+        with pytest.raises(ValueError):
+            click_answer("E", region)
+        mock_click.assert_not_called()
+
+
+def test_click_answer_custom_option_count():
+    region = (0, 0, 100, 500)
+    with patch("quiz_automation.clicker.pyautogui.click") as mock_click:
+        x, y = click_answer("E", region, num_options=5)
+        mock_click.assert_called_once_with(x, y)
+        assert (x, y) == (50, 450)


### PR DESCRIPTION
## Summary
- extend `click_answer` to accept custom option counts or explicit offset maps
- raise `ValueError` for unknown answer letters
- add tests for invalid letters and quizzes with more options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b72feac1c8328a709a619f4d0b453