### PR TITLE
Enable injectable screenshot and OCR in watcher

### DIFF
--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -9,3 +9,29 @@ def test_is_new_question():
     assert watcher.is_new_question("q1")
     watcher._last_text = "q1"
     assert not watcher.is_new_question("q1")
+
+
+def test_run_triggers_on_question(mocker):
+    capture = mocker.Mock(return_value=None)
+    texts = ["q1", "q1"]
+
+    def ocr(_):
+        if texts:
+            return texts.pop(0)
+        watcher.stop_flag.set()
+        return ""
+
+    ocr_mock = mocker.Mock(side_effect=ocr)
+    on_question = mocker.Mock()
+
+    watcher = Watcher(
+        (0, 0, 1, 1),
+        on_question,
+        poll_interval=0.01,
+        capture=capture,
+        ocr=ocr_mock,
+    )
+    watcher.start()
+    watcher.join(timeout=1)
+    assert not watcher.is_alive()
+    on_question.assert_called_once_with("q1")


### PR DESCRIPTION
## Summary
- allow Watcher to accept capture and OCR callables with default mss+pytesseract implementations
- ensure watcher thread stops promptly by waiting on stop flag
- test Watcher run loop with mocked capture and OCR functions

## Testing
- `ruff check quiz_automation tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b72ffe4388328a4e1cce62d7a941c