### PR TITLE
Use BaseSettings for environment-driven config

### DIFF
--- a/quiz_automation/chatgpt_client.py
+++ b/quiz_automation/chatgpt_client.py
@@ -8,14 +8,15 @@ import time
 
 from openai import OpenAI
 
-from .config import settings
+from .config import get_settings
 
 
 class ChatGPTClient:
     """Client for querying ChatGPT models."""
 
     def __init__(self) -> None:
-        self.client = OpenAI(api_key=settings.openai_api_key)
+        self.settings = get_settings()
+        self.client = OpenAI(api_key=self.settings.openai_api_key)
 
     def ask(self, question: str) -> str:
         """Send question to model and return parsed answer letter."""
@@ -24,8 +25,8 @@ class ChatGPTClient:
         for attempt in range(3):
             try:
                 completion = self.client.responses.create(
-                    model=settings.openai_model,
-                    temperature=settings.openai_temperature,
+                    model=self.settings.openai_model,
+                    temperature=self.settings.openai_temperature,
                     input=prompt,
                 )
                 try:

--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -2,19 +2,29 @@
 
 from __future__ import annotations
 
+import os
+
 from dotenv import load_dotenv
-from pydantic import BaseModel
+from pydantic import Field
+from pydantic_settings import BaseSettings
 
-load_dotenv()
 
-
-class Settings(BaseModel):
+class Settings(BaseSettings):
     """Runtime settings for the quiz automation tool."""
 
-    openai_api_key: str = ""
-    openai_model: str = "gpt-4o-mini-high"
-    openai_temperature: float = 0.0
-    poll_interval: float = 0.5
+    openai_api_key: str = Field(..., env="OPENAI_API_KEY")
+    openai_model: str = Field("gpt-4o-mini-high", env="OPENAI_MODEL")
+    openai_temperature: float = Field(0.0, env="OPENAI_TEMPERATURE")
+    poll_interval: float = Field(0.5, env="POLL_INTERVAL")
 
 
-settings = Settings()
+def get_settings() -> Settings:
+    """Return runtime configuration loaded from environment variables."""
+    load_dotenv()
+    return Settings(
+        openai_api_key=os.getenv("OPENAI_API_KEY", ""),
+        openai_model=os.getenv("OPENAI_MODEL", "gpt-4o-mini-high"),
+        openai_temperature=float(os.getenv("OPENAI_TEMPERATURE", 0.0)),
+        poll_interval=float(os.getenv("POLL_INTERVAL", 0.5)),
+    )
+

--- a/quiz_automation/gui.py
+++ b/quiz_automation/gui.py
@@ -6,7 +6,7 @@ import queue
 import tkinter as tk
 from typing import Optional
 
-from .config import settings
+from .config import get_settings
 from .watcher import Watcher
 from .region_selector import Region, select_region
 
@@ -21,6 +21,7 @@ class QuizGUI:
         self.event_queue: "queue.Queue[str]" = queue.Queue()
         self.watcher: Optional[Watcher] = None
         self.region: Optional[Region] = None
+        self.settings = get_settings()
 
         start_btn = tk.Button(self.root, text="Start", command=self.start)
         start_btn.pack()
@@ -34,7 +35,9 @@ class QuizGUI:
         if self.watcher is None:
             if self.region is None:
                 self.region = select_region()
-            self.watcher = Watcher(self.region.as_tuple(), self.on_question, settings.poll_interval)
+            self.watcher = Watcher(
+                self.region.as_tuple(), self.on_question, self.settings.poll_interval
+            )
             self.watcher.start()
             self.status_var.set("Running")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pytesseract==0.3.10
 pyautogui==0.9.54
 python-dotenv==1.0.1
 pydantic==2.7.4
+pydantic-settings==2.2.1
 openai==1.30.1
 pillow==10.2.0
 numpy==1.26.4

--- a/tests/stubs/pydantic/__init__.py
+++ b/tests/stubs/pydantic/__init__.py
@@ -1,6 +1,11 @@
-"""Minimal stub of Pydantic BaseModel."""
+"""Minimal stubs for Pydantic features used in tests."""
 
 from __future__ import annotations
+
+
+def Field(default, **kwargs):  # noqa: D401 - simple stub
+    """Return the provided default value."""
+    return default
 
 
 class BaseModel:

--- a/tests/stubs/pydantic_settings/__init__.py
+++ b/tests/stubs/pydantic_settings/__init__.py
@@ -1,0 +1,10 @@
+"""Minimal stub for pydantic_settings.BaseSettings."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel as _BaseModel
+
+
+class BaseSettings(_BaseModel):
+    pass
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,25 @@
-from quiz_automation.config import settings
+from quiz_automation.config import get_settings
 
 
-def test_config_defaults():
+def test_config_defaults(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_MODEL", raising=False)
+    monkeypatch.delenv("OPENAI_TEMPERATURE", raising=False)
+    monkeypatch.delenv("POLL_INTERVAL", raising=False)
+    settings = get_settings()
     assert settings.poll_interval == 0.5
     assert settings.openai_model == "gpt-4o-mini-high"
     assert settings.openai_temperature == 0.0
+
+
+def test_env_vars(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "abc")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4o-mini")
+    monkeypatch.setenv("OPENAI_TEMPERATURE", "0.7")
+    monkeypatch.setenv("POLL_INTERVAL", "1.0")
+    settings = get_settings()
+    assert settings.openai_api_key == "abc"
+    assert settings.openai_model == "gpt-4o-mini"
+    assert settings.openai_temperature == 0.7
+    assert settings.poll_interval == 1.0
+


### PR DESCRIPTION
## Summary
- Load configuration with `pydantic_settings.BaseSettings` and lazy `get_settings()`
- Add environment variable fields and update modules to fetch settings at runtime
- Provide test stubs and tests for default and environment overrides

## Testing
- `ruff check quiz_automation tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9e3df1608328998ad4aada58b01d