### PR TITLE
feat: add draggable region selector

### DIFF
--- a/quiz_automation/region_selector.py
+++ b/quiz_automation/region_selector.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Tuple
 
+import pyautogui
+import tkinter as tk
+
 
 @dataclass
 class Region:
@@ -21,5 +24,56 @@ class Region:
 
 
 def select_region() -> Region:
-    """Placeholder region selector returning a default box."""
-    return Region(0, 0, 100, 100)
+    """Display a full-screen overlay allowing the user to drag out a region.
+
+    A translucent Tk window is shown over the entire screen. The user clicks and
+    drags to draw a rectangle representing the desired capture region. When the
+    mouse button is released a :class:`Region` describing the rectangle is
+    returned.
+    """
+
+    # Determine the size of the current screen using pyautogui so the overlay
+    # covers the whole area.
+    screen_w, screen_h = pyautogui.size()
+
+    root = tk.Tk()
+    root.overrideredirect(True)
+    root.attributes("-topmost", True)
+    root.attributes("-alpha", 0.3)
+    root.geometry(f"{screen_w}x{screen_h}+0+0")
+
+    canvas = tk.Canvas(root, cursor="cross")
+    canvas.pack(fill=tk.BOTH, expand=True)
+
+    start_x = start_y = 0
+    selection = {"region": Region(0, 0, 0, 0)}
+
+    def on_press(event: tk.Event) -> None:
+        """Remember the starting mouse position and draw the rectangle."""
+        nonlocal start_x, start_y
+        start_x, start_y = pyautogui.position()
+        canvas.delete("rect")
+        canvas.create_rectangle(start_x, start_y, start_x, start_y, outline="red", tags="rect")
+
+    def on_drag(event: tk.Event) -> None:
+        """Update the rectangle as the mouse moves."""
+        current_x, current_y = pyautogui.position()
+        canvas.coords("rect", start_x, start_y, current_x, current_y)
+
+    def on_release(event: tk.Event) -> None:
+        """Finalize region and exit the overlay."""
+        end_x, end_y = pyautogui.position()
+        left = min(start_x, end_x)
+        top = min(start_y, end_y)
+        width = abs(end_x - start_x)
+        height = abs(end_y - start_y)
+        selection["region"] = Region(left, top, width, height)
+        root.quit()
+
+    canvas.bind("<ButtonPress-1>", on_press)
+    canvas.bind("<B1-Motion>", on_drag)
+    canvas.bind("<ButtonRelease-1>", on_release)
+
+    root.mainloop()
+    root.destroy()
+    return selection["region"]

--- a/tests/test_region_selector.py
+++ b/tests/test_region_selector.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 from quiz_automation.region_selector import Region, select_region
 
 
@@ -6,6 +8,36 @@ def test_region_as_tuple():
     assert r.as_tuple() == (1, 2, 3, 4)
 
 
-def test_select_region_returns_region():
-    r = select_region()
-    assert isinstance(r, Region)
+def test_select_region_user_drag():
+    """Simulate a user dragging a box and ensure coordinates are returned."""
+    callbacks = {}
+
+    mock_root = MagicMock()
+    mock_canvas = MagicMock()
+
+    def bind(event, func):
+        callbacks[event] = func
+
+    mock_canvas.bind.side_effect = bind
+
+    def fake_mainloop():
+        callbacks["<ButtonPress-1>"](MagicMock())
+        callbacks["<ButtonRelease-1>"](MagicMock())
+
+    mock_root.mainloop.side_effect = fake_mainloop
+
+    with patch("quiz_automation.region_selector.tk.Tk", return_value=mock_root), \
+        patch("quiz_automation.region_selector.tk.Canvas", return_value=mock_canvas), \
+        patch(
+            "quiz_automation.region_selector.pyautogui.position",
+            side_effect=[(10, 20), (110, 120)],
+            create=True,
+        ), \
+        patch(
+            "quiz_automation.region_selector.pyautogui.size",
+            return_value=(200, 200),
+            create=True,
+        ):
+        region = select_region()
+
+    assert region.as_tuple() == (10, 20, 100, 100)


### PR DESCRIPTION
## Summary
- allow users to drag a box on screen to choose capture region
- test region selection by mocking drag events

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b9e3ed10483288305d5b9828884a7