### PR TITLE
Integrate ChatGPT answer flow with GUI logging

### DIFF
--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -33,7 +33,13 @@ def test_gui_start_stop(monkeypatch):
         def after(self, ms, func):
             pass
 
+        def protocol(self, name, func):
+            pass
+
         def mainloop(self):
+            pass
+
+        def destroy(self):
             pass
 
     class DummyStringVar:
@@ -55,9 +61,20 @@ def test_gui_start_stop(monkeypatch):
         calls['count'] += 1
         return Region(0, 0, 1, 1)
 
+    class DummyLogger:
+        def __init__(self, path):
+            pass
+
+        def log(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
     monkeypatch.setattr("quiz_automation.gui.tk", dummy_tk)
     monkeypatch.setattr("quiz_automation.gui.Watcher", DummyWatcher)
     monkeypatch.setattr("quiz_automation.gui.select_region", dummy_select_region)
+    monkeypatch.setattr("quiz_automation.gui.QuizLogger", DummyLogger)
 
     gui = QuizGUI()
     gui.start()

--- a/tests/test_gui_integration.py
+++ b/tests/test_gui_integration.py
@@ -1,0 +1,102 @@
+from types import SimpleNamespace
+
+from quiz_automation.gui import QuizGUI
+from quiz_automation.region_selector import Region
+
+
+def test_on_question_flow(monkeypatch):
+    calls = {}
+
+    class DummyClient:
+        def __init__(self):
+            pass
+
+        def ask(self, question: str) -> str:
+            calls['question'] = question
+            return 'B'
+
+    def dummy_click(letter, region, offsets_map=None, num_options=None):
+        calls['click'] = (letter, region)
+        return 10, 20
+
+    class DummyLogger:
+        def __init__(self, path):
+            calls['path'] = str(path)
+
+        def log(self, ts, question, answer, x, y):
+            calls['log'] = (ts, question, answer, x, y)
+
+        def close(self):
+            calls['closed'] = True
+
+    class DummyWidget:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def pack(self):
+            pass
+
+    class DummyTk(DummyWidget):
+        def title(self, text):
+            pass
+
+        def after(self, ms, func):
+            pass
+
+        def protocol(self, name, func):
+            pass
+
+        def mainloop(self):
+            pass
+
+        def destroy(self):
+            pass
+
+    class DummyStringVar:
+        def __init__(self, value=""):
+            self.value = value
+
+        def set(self, value: str) -> None:
+            self.value = value
+
+        def get(self) -> str:
+            return self.value
+
+    class DummyDateTime:
+        @staticmethod
+        def now():
+            class D:
+                @staticmethod
+                def isoformat():
+                    return "TS"
+            return D()
+
+    dummy_tk = SimpleNamespace(
+        Tk=DummyTk, Button=DummyWidget, Label=DummyWidget, StringVar=DummyStringVar
+    )
+
+    monkeypatch.setattr("quiz_automation.gui.ChatGPTClient", DummyClient)
+    monkeypatch.setattr("quiz_automation.gui.click_answer", dummy_click)
+    monkeypatch.setattr("quiz_automation.gui.QuizLogger", DummyLogger)
+    monkeypatch.setattr("quiz_automation.gui.tk", dummy_tk)
+    monkeypatch.setattr("quiz_automation.gui.datetime", DummyDateTime)
+
+    gui = QuizGUI()
+    gui.region = Region(0, 0, 50, 50)
+    gui.on_question("What is 2+2?")
+
+    assert calls['question'] == "What is 2+2?"
+    assert calls['click'] == (
+        'B',
+        (0, 0, 50, 50),
+    )
+    assert calls['log'] == (
+        "TS",
+        "What is 2+2?",
+        'B',
+        10,
+        20,
+    )
+
+    gui.shutdown()
+    assert calls['closed'] is True


### PR DESCRIPTION
## Summary
- Instantiate ChatGPT client, answer clicker, and SQLite logger in GUI
- Forward questions through ChatGPT, click answers, and log events with timestamp and coordinates
- Add end-to-end integration test mocking external services

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b9e3f6c0c83288455232f96e81c24