### PR TITLE
Handle capture/OCR failures in Watcher thread

### DIFF
--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,3 +1,5 @@
+from threading import Event
+
 from quiz_automation.watcher import Watcher
 
 
@@ -35,3 +37,47 @@ def test_run_triggers_on_question(mocker):
     watcher.join(timeout=1)
     assert not watcher.is_alive()
     on_question.assert_called_once_with("q1")
+
+
+def test_run_survives_capture_and_ocr_errors(mocker):
+    capture_event = Event()
+    ocr_event = Event()
+    errors: list[Exception] = []
+
+    def capture(_):
+        if not capture_event.is_set():
+            capture_event.set()
+            raise RuntimeError("capture fail")
+        return None
+
+    def ocr(_):
+        if not ocr_event.is_set():
+            ocr_event.set()
+            raise RuntimeError("ocr fail")
+        watcher.stop_flag.set()
+        return "q1"
+
+    on_question = mocker.Mock()
+
+    watcher = Watcher(
+        (0, 0, 1, 1),
+        on_question,
+        poll_interval=0.01,
+        capture=capture,
+        ocr=ocr,
+        on_error=errors.append,
+    )
+
+    watcher.start()
+
+    assert capture_event.wait(0.5)
+    assert watcher.is_alive()
+
+    assert ocr_event.wait(0.5)
+    assert watcher.is_alive()
+
+    watcher.join(timeout=1)
+    assert not watcher.is_alive()
+
+    on_question.assert_called_once_with("q1")
+    assert len(errors) == 2


### PR DESCRIPTION
## Summary
- ensure Watcher thread logs and handles errors from screen capture and OCR without stopping
- allow optional error callback for GUI notifications
- test that Watcher survives capture/OCR failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b9e4017c08328b2a306bb77b272fa