### PR TITLE
Refactor GUI for dependency injection and watcher safety

### DIFF
--- a/quiz_automation/chatgpt_client.py
+++ b/quiz_automation/chatgpt_client.py
@@ -11,11 +11,17 @@ from openai import OpenAI
 from .config import get_settings
 
 
+settings = get_settings()
+
+
 class ChatGPTClient:
     """Client for querying ChatGPT models."""
 
     def __init__(self) -> None:
-
+        self.settings = settings
+        if not self.settings.openai_api_key:
+            raise ValueError("API key is required")
+        self.client = OpenAI(self.settings.openai_api_key)
 
     def ask(self, question: str) -> str:
         """Send question to model and return parsed answer letter."""


### PR DESCRIPTION
## Summary
- allow `QuizGUI` to accept injectable ChatGPT client, logger, and clicker
- guard against multiple watcher threads and use configured poll interval
- implement `ChatGPTClient` initialization with settings and API key validation

## Testing
- `OPENAI_API_KEY=test pytest tests/test_gui.py tests/test_gui_integration.py -q`
- `OPENAI_API_KEY=test pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689be7e010ec8328a61efa705a55703b