### PR TITLE
Add caching mechanism to ChatGPT client

### DIFF
--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -75,6 +75,12 @@ def test_gui_start_stop(monkeypatch):
     monkeypatch.setattr("quiz_automation.gui.Watcher", DummyWatcher)
     monkeypatch.setattr("quiz_automation.gui.select_region", dummy_select_region)
     monkeypatch.setattr("quiz_automation.gui.QuizLogger", DummyLogger)
+    monkeypatch.setattr(
+        "quiz_automation.chatgpt_client.OpenAI", lambda api_key: SimpleNamespace()
+    )
+    monkeypatch.setattr(
+        "quiz_automation.chatgpt_client.settings.openai_api_key", "test-key"
+    )
 
     gui = QuizGUI()
     gui.start()


### PR DESCRIPTION
## Summary
- implement module-level hashed question cache in ChatGPTClient
- allow injecting cache for tests and cache successful responses
- add regression tests for caching and adjust GUI test setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c893ee890832885e3081867bde6e3