### PR TITLE
Refactor ChatGPT client initialization

### DIFF
--- a/quiz_automation/chatgpt_client.py
+++ b/quiz_automation/chatgpt_client.py
@@ -15,20 +15,28 @@ from .config import Settings, get_settings
 settings = get_settings()
 
 
-settings = get_settings()
-
-
 class ChatGPTClient:
     """Client for querying ChatGPT models.
 
     This lightweight wrapper around the OpenAI client is primarily used by the
     quiz automation scripts. The constructor allows dependency injection of
-    both the OpenAI client and runtime settings which simplifies testing.
+    both the OpenAI client and runtime settings which simplifies testing, and
+    the :meth:`ask` method retries API calls with exponential backoff.
     """
 
     def __init__(self, client: OpenAI | None = None, settings: Settings | None = None) -> None:
-        """Initialize the client.
+        """Initialize the ChatGPT client.
 
+        Allows dependency injection of both a preconfigured OpenAI client and
+        runtime settings for testing. The :meth:`ask` method will retry failed
+        requests with exponential backoff.
+        """
+
+        settings = settings or globals()["settings"]
+        if not settings.openai_api_key:
+            raise ValueError("API key is required")
+        self.client = client or OpenAI(api_key=settings.openai_api_key)
+        self.settings = settings
 
     def ask(self, question: str) -> str:
         """Send question to model and return parsed answer letter.

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -75,6 +75,9 @@ def test_gui_start_stop(monkeypatch):
     monkeypatch.setattr("quiz_automation.gui.Watcher", DummyWatcher)
     monkeypatch.setattr("quiz_automation.gui.select_region", dummy_select_region)
     monkeypatch.setattr("quiz_automation.gui.QuizLogger", DummyLogger)
+    monkeypatch.setattr(
+        "quiz_automation.chatgpt_client.settings.openai_api_key", "test-key"
+    )
 
     gui = QuizGUI()
     gui.start()


### PR DESCRIPTION
## Summary
- simplify ChatGPT client configuration by using a single module-level settings instance
- allow injecting client and settings, validate API key, and create OpenAI client lazily
- patch GUI tests to provide API key when constructing QuizGUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c89408cec8328a1fddfa4c713daec