### PR TITLE
Refactor ChatGPT client initialization

### DIFF
--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -4,7 +4,15 @@ from quiz_automation.gui import QuizGUI
 from quiz_automation.region_selector import Region
 
 
+def _ensure_api_key(monkeypatch) -> None:
+    """Ensure ChatGPTClient has an API key for instantiation."""
+    monkeypatch.setattr(
+        "quiz_automation.chatgpt_client.settings.openai_api_key", "test-key"
+    )
+
+
 def test_gui_start_stop(monkeypatch):
+    _ensure_api_key(monkeypatch)
     started = {}
 
     class DummyWatcher:


### PR DESCRIPTION
## Summary
- Remove duplicate `settings = get_settings()` and expose a single module-level instance.
- Allow dependency injection in `ChatGPTClient.__init__` with optional client and settings parameters.
- Validate `openai_api_key` and build default `OpenAI` client.
- Document initialization behavior and update GUI test to supply a dummy API key.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c893d60448328bf280c7ab142c45a