### PR TITLE
Add caching layer to ChatGPT client

### DIFF
--- a/quiz_automation/chatgpt_client.py
+++ b/quiz_automation/chatgpt_client.py
@@ -11,7 +11,29 @@ from openai import OpenAI
 from .config import Settings, get_settings
 from .utils import hash_text
 
+settings = get_settings()
+CACHE: dict[str, str] = {}
 
+
+class ChatGPTClient:
+    """Thin wrapper around the OpenAI client."""
+
+    def __init__(
+        self,
+        settings: Settings | None = None,
+        cache: dict[str, str] | None = None,
+    ) -> None:
+        self.settings = settings if settings is not None else globals()["settings"]
+        if not self.settings.openai_api_key:
+            raise ValueError("API key is required")
+        self.client = OpenAI(api_key=self.settings.openai_api_key)
+        self.cache = CACHE if cache is None else cache
+
+    def ask(self, question: str) -> tuple[str, SimpleNamespace | None, float]:
+        """Return answer, usage and cost for *question*."""
+        key = hash_text(question)
+        if key in self.cache:
+            return self.cache[key], None, 0.0
 
         prompt = f"Answer the quiz question with a single letter in JSON: {question}"
         backoff = 1.0
@@ -25,11 +47,23 @@ from .utils import hash_text
                 try:
                     data = json.loads(completion.output[0].content[0].text)
                     answer = data.get("answer", "")
-
                 except (KeyError, IndexError, json.JSONDecodeError):
+                    return "Error: malformed response", None, 0.0
 
+                usage = getattr(completion, "usage", None)
+                cost = 0.0
+                if usage is not None:
+                    input_tokens = getattr(usage, "input_tokens", 0)
+                    output_tokens = getattr(usage, "output_tokens", 0)
+                    input_cost = getattr(self.settings, "openai_input_cost", 0.0)
+                    output_cost = getattr(self.settings, "openai_output_cost", 0.0)
+                    cost = (input_tokens * input_cost + output_tokens * output_cost) / 1000
+
+                self.cache[key] = answer
+                return answer, usage, cost
+            except Exception:
                 if attempt == 2:
                     return "Error: API request failed", None, 0.0
                 time.sleep(backoff)
                 backoff *= 2
-
+        return "Error: API request failed", None, 0.0

--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -16,6 +16,8 @@ class Settings(BaseSettings):
     openai_api_key: str = Field(..., env="OPENAI_API_KEY")
     openai_model: str = Field("gpt-4o-mini-high", env="OPENAI_MODEL")
     openai_temperature: float = Field(0.0, env="OPENAI_TEMPERATURE")
+    openai_input_cost: float = Field(0.0, env="OPENAI_INPUT_COST")
+    openai_output_cost: float = Field(0.0, env="OPENAI_OUTPUT_COST")
     poll_interval: float = Field(0.5, env="POLL_INTERVAL")
     screenshot_dir: Path | None = Field(None, env="SCREENSHOT_DIR")
 
@@ -28,6 +30,8 @@ def get_settings() -> Settings:
         openai_api_key=os.getenv("OPENAI_API_KEY", ""),
         openai_model=os.getenv("OPENAI_MODEL", "gpt-4o-mini-high"),
         openai_temperature=float(os.getenv("OPENAI_TEMPERATURE", 0.0)),
+        openai_input_cost=float(os.getenv("OPENAI_INPUT_COST", 0.0)),
+        openai_output_cost=float(os.getenv("OPENAI_OUTPUT_COST", 0.0)),
         poll_interval=float(os.getenv("POLL_INTERVAL", 0.5)),
 
     )

--- a/tests/test_chatgpt_client.py
+++ b/tests/test_chatgpt_client.py
@@ -137,7 +137,10 @@ def test_chatgpt_client_uses_cache(monkeypatch):
     )
 
     client = ChatGPTClient()
-    assert client.ask("question") == "A"
-    assert client.ask("question") == "A"
+    answer1, _, _ = client.ask("question")
+    answer2, usage2, cost2 = client.ask("question")
+    assert answer1 == answer2 == "A"
+    assert usage2 is None
+    assert cost2 == 0.0
     assert counting.calls == 1
 


### PR DESCRIPTION
## Summary
- add module-level cache with hash-based keys for ChatGPT answers
- allow ChatGPTClient to accept an optional cache and use it in `ask`
- include token cost configuration settings
- test that repeated questions use cache instead of OpenAI

## Testing
- `pytest tests/test_chatgpt_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cc14423d88328b4f68e0bf44b0553