### PR TITLE
Implement ChatGPT client with caching and cost accounting

### DIFF
--- a/quiz_automation/chatgpt_client.py
+++ b/quiz_automation/chatgpt_client.py
@@ -5,13 +5,61 @@ from __future__ import annotations
 import json
 import time
 from types import SimpleNamespace
+from typing import Dict, Tuple
 
 from openai import OpenAI
 
 from .config import Settings, get_settings
 from .utils import hash_text
 
+settings = get_settings()
+CACHE: Dict[str, str] = {}
 
+
+class ChatGPTClient:
+    """Minimal wrapper around OpenAI's Responses API.
+
+    Parameters
+    ----------
+    client:
+        Optional pre-configured :class:`OpenAI` client instance.
+    cache:
+        Mutable mapping used to store question/answer pairs.
+    settings:
+        Runtime configuration. Defaults to module-level ``settings``.
+    """
+
+    def __init__(
+        self,
+        client: OpenAI | None = None,
+        cache: Dict[str, str] | None = None,
+        settings: Settings | None = None,
+    ) -> None:
+        self.settings = settings or globals()["settings"]
+        if not self.settings.openai_api_key:
+            raise ValueError("API key is required")
+        self.client = client or OpenAI(api_key=self.settings.openai_api_key)
+        self.cache = cache or CACHE
+
+    def ask(self, question: str) -> Tuple[str, SimpleNamespace | None, float]:
+        """Send ``question`` to OpenAI and return the parsed answer.
+
+        The method caches answers by the hash of ``question``. On subsequent
+        calls with the same question the cached answer is returned and the
+        usage and cost values are ``None`` and ``0.0`` respectively.
+
+        Returns
+        -------
+        tuple
+            ``(answer, usage, cost)`` where ``answer`` is the extracted
+            single-letter response, ``usage`` is the token usage object from
+            OpenAI (or ``None`` when unavailable) and ``cost`` is the estimated
+            dollar cost of the request.
+        """
+
+        qid = hash_text(question)
+        if qid in self.cache:
+            return self.cache[qid], None, 0.0
 
         prompt = f"Answer the quiz question with a single letter in JSON: {question}"
         backoff = 1.0
@@ -25,11 +73,24 @@ from .utils import hash_text
                 try:
                     data = json.loads(completion.output[0].content[0].text)
                     answer = data.get("answer", "")
-
                 except (KeyError, IndexError, json.JSONDecodeError):
+                    return "Error: malformed response", None, 0.0
 
+                usage = getattr(completion, "usage", None)
+                cost = 0.0
+                if usage is not None:
+                    in_cost = getattr(self.settings, "openai_input_cost", 0.0)
+                    out_cost = getattr(self.settings, "openai_output_cost", 0.0)
+                    cost = (
+                        usage.input_tokens * in_cost
+                        + usage.output_tokens * out_cost
+                    ) / 1000
+                self.cache[qid] = answer
+                return answer, usage, cost
+            except Exception:
                 if attempt == 2:
                     return "Error: API request failed", None, 0.0
                 time.sleep(backoff)
                 backoff *= 2
 
+        return "Error: API request failed", None, 0.0

--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -18,6 +18,8 @@ class Settings(BaseSettings):
     openai_temperature: float = Field(0.0, env="OPENAI_TEMPERATURE")
     poll_interval: float = Field(0.5, env="POLL_INTERVAL")
     screenshot_dir: Path | None = Field(None, env="SCREENSHOT_DIR")
+    openai_input_cost: float = Field(0.0, env="OPENAI_INPUT_COST")
+    openai_output_cost: float = Field(0.0, env="OPENAI_OUTPUT_COST")
 
 
 
@@ -29,6 +31,8 @@ def get_settings() -> Settings:
         openai_model=os.getenv("OPENAI_MODEL", "gpt-4o-mini-high"),
         openai_temperature=float(os.getenv("OPENAI_TEMPERATURE", 0.0)),
         poll_interval=float(os.getenv("POLL_INTERVAL", 0.5)),
+        openai_input_cost=float(os.getenv("OPENAI_INPUT_COST", 0.0)),
+        openai_output_cost=float(os.getenv("OPENAI_OUTPUT_COST", 0.0)),
 
     )
 

--- a/tests/test_chatgpt_client.py
+++ b/tests/test_chatgpt_client.py
@@ -137,7 +137,11 @@ def test_chatgpt_client_uses_cache(monkeypatch):
     )
 
     client = ChatGPTClient()
-    assert client.ask("question") == "A"
-    assert client.ask("question") == "A"
+    answer1, _, _ = client.ask("question")
+    answer2, usage2, cost2 = client.ask("question")
+    assert answer1 == "A"
+    assert answer2 == "A"
+    assert usage2 is None
+    assert cost2 == 0.0
     assert counting.calls == 1
 


### PR DESCRIPTION
## Summary
- rebuild ChatGPT client with caching, OpenAI usage tracking, and cost calculation
- extend settings with input/output token cost configuration
- update tests for new return signature and caching behavior

## Testing
- `pytest -q` *(fails: IndentationError in watcher and SyntaxError in tests unrelated to chatgpt client)*
- `pytest tests/test_chatgpt_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf53f616c832881bfed88644445e7