### PR TITLE
feat: add screenshot directory configuration

### DIFF
--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -22,13 +22,17 @@ class Settings(BaseSettings):
 
 
 def get_settings() -> Settings:
-    """Return runtime configuration loaded from environment variables."""
+    """Return runtime configuration loaded from environment variables.
+
+    Includes optional screenshot archiving when ``SCREENSHOT_DIR`` is set.
+    """
     load_dotenv()
+    screenshot_dir = os.getenv("SCREENSHOT_DIR")
     return Settings(
         openai_api_key=os.getenv("OPENAI_API_KEY", ""),
         openai_model=os.getenv("OPENAI_MODEL", "gpt-4o-mini-high"),
         openai_temperature=float(os.getenv("OPENAI_TEMPERATURE", 0.0)),
         poll_interval=float(os.getenv("POLL_INTERVAL", 0.5)),
-
+        screenshot_dir=Path(screenshot_dir) if screenshot_dir else None,
     )
 


### PR DESCRIPTION
## Summary
- support optional screenshot archiving by including `screenshot_dir` in settings
- document screenshot archiving in configuration helper

## Testing
- `pytest tests/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_689cf543728c8328951550a9bc842d15