### PR TITLE
Add cache tuple assertions and watcher screenshot test

### DIFF
--- a/tests/test_chatgpt_client.py
+++ b/tests/test_chatgpt_client.py
@@ -137,7 +137,9 @@ def test_chatgpt_client_uses_cache(monkeypatch):
     )
 
     client = ChatGPTClient()
-    assert client.ask("question") == "A"
-    assert client.ask("question") == "A"
+    answer, *_ = client.ask("question")
+    assert answer == "A"
+    answer, *_ = client.ask("question")
+    assert answer == "A"
     assert counting.calls == 1
 


### PR DESCRIPTION
## Summary
- Update ChatGPT client cache test to unpack the returned tuple before asserting the cached answer
- Finish watcher tests and add coverage for screenshot saving in a temporary directory

## Testing
- `pytest tests/test_chatgpt_client.py::test_chatgpt_client_uses_cache -q` *(fails: IndentationError in quiz_automation/chatgpt_client.py)*
- `pytest tests/test_watcher.py::test_run_saves_screenshot -q` *(fails: IndentationError in quiz_automation/watcher.py)*

------
https://chatgpt.com/codex/tasks/task_e_689cf5447c7c8328bb6ac50cd534f922