### PR TITLE
Add configuration for OpenAI cost tracking and screenshots

### DIFF
--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -18,17 +18,25 @@ class Settings(BaseSettings):
     openai_temperature: float = Field(0.0, env="OPENAI_TEMPERATURE")
     poll_interval: float = Field(0.5, env="POLL_INTERVAL")
     screenshot_dir: Path | None = Field(None, env="SCREENSHOT_DIR")
+    openai_input_cost: float = Field(0.0, env="OPENAI_INPUT_COST")
+    openai_output_cost: float = Field(0.0, env="OPENAI_OUTPUT_COST")
 
 
 
 def get_settings() -> Settings:
-    """Return runtime configuration loaded from environment variables."""
+    """Return runtime configuration loaded from environment variables.
+
+    Includes paths for screenshot archiving and cost configuration for
+    OpenAI usage.
+    """
     load_dotenv()
     return Settings(
         openai_api_key=os.getenv("OPENAI_API_KEY", ""),
         openai_model=os.getenv("OPENAI_MODEL", "gpt-4o-mini-high"),
         openai_temperature=float(os.getenv("OPENAI_TEMPERATURE", 0.0)),
         poll_interval=float(os.getenv("POLL_INTERVAL", 0.5)),
-
+        screenshot_dir=Path(os.getenv("SCREENSHOT_DIR")) if os.getenv("SCREENSHOT_DIR") else None,
+        openai_input_cost=float(os.getenv("OPENAI_INPUT_COST", 0.0)),
+        openai_output_cost=float(os.getenv("OPENAI_OUTPUT_COST", 0.0)),
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,8 @@ def test_config_defaults(monkeypatch):
     assert settings.openai_model == "gpt-4o-mini-high"
     assert settings.openai_temperature == 0.0
     assert settings.screenshot_dir is None
+    assert settings.openai_input_cost == 0.0
+    assert settings.openai_output_cost == 0.0
 
 
 
@@ -21,10 +23,14 @@ def test_env_vars(monkeypatch):
     monkeypatch.setenv("OPENAI_TEMPERATURE", "0.7")
     monkeypatch.setenv("POLL_INTERVAL", "1.0")
     monkeypatch.setenv("SCREENSHOT_DIR", "/tmp")
+    monkeypatch.setenv("OPENAI_INPUT_COST", "0.002")
+    monkeypatch.setenv("OPENAI_OUTPUT_COST", "0.004")
     settings = get_settings()
     assert settings.openai_api_key == "abc"
     assert settings.openai_model == "gpt-4o-mini"
     assert settings.openai_temperature == 0.7
     assert settings.poll_interval == 1.0
     assert str(settings.screenshot_dir) == "/tmp"
+    assert settings.openai_input_cost == 0.002
+    assert settings.openai_output_cost == 0.004
 


### PR DESCRIPTION
## Summary
- add input/output cost fields to `Settings`
- load screenshot directory and cost fields from environment in `get_settings`
- document screenshot archiving and cost configuration
- test config cost settings

## Testing
- `pytest tests/test_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689d3fe324688328b3bf11bbae70ad24