### PR TITLE
Handle OpenAI cost settings and tests

### DIFF
--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -35,6 +35,8 @@ def get_settings() -> Settings:
         openai_model=os.getenv("OPENAI_MODEL", "gpt-4o-mini-high"),
         openai_temperature=float(os.getenv("OPENAI_TEMPERATURE", 0.0)),
         poll_interval=float(os.getenv("POLL_INTERVAL", 0.5)),
-
+        screenshot_dir=Path(screenshot_dir) if screenshot_dir else None,
+        openai_input_cost=float(os.getenv("OPENAI_INPUT_COST", 0.0)),
+        openai_output_cost=float(os.getenv("OPENAI_OUTPUT_COST", 0.0)),
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,10 +2,14 @@ from quiz_automation.config import get_settings
 
 
 def test_config_defaults(monkeypatch):
+    """Ensure environment defaults are applied when variables are absent."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_MODEL", raising=False)
     monkeypatch.delenv("OPENAI_TEMPERATURE", raising=False)
     monkeypatch.delenv("POLL_INTERVAL", raising=False)
+    monkeypatch.delenv("SCREENSHOT_DIR", raising=False)
+    monkeypatch.delenv("OPENAI_INPUT_COST", raising=False)
+    monkeypatch.delenv("OPENAI_OUTPUT_COST", raising=False)
 
     settings = get_settings()
     assert settings.poll_interval == 0.5
@@ -16,8 +20,7 @@ def test_config_defaults(monkeypatch):
     assert settings.openai_output_cost == 0.0
 
 
-
-def test_env_vars(monkeypatch):
+def test_env_var_overrides(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "abc")
     monkeypatch.setenv("OPENAI_MODEL", "gpt-4o-mini")
     monkeypatch.setenv("OPENAI_TEMPERATURE", "0.7")


### PR DESCRIPTION
## Summary
- parse screenshot directory and OpenAI token costs in settings
- add tests for config defaults and environment overrides

## Testing
- `pytest -q` *(fails: IndentationError in unrelated modules)*
- `pytest tests/test_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d7bf43ae88328ba591705831ba0f5