### PR TITLE
Add CI workflow with ruff and pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,34 @@
 name: CI
 
+on:
+  push:
+  pull_request:
 
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run ruff
+        run: ruff check .
+      - name: Run tests
+        env:
+          OPENAI_API_KEY: dummy
+        run: pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions CI that runs ruff and pytest on Python 3.11
- cache pip dependencies using requirements.txt hash

## Testing
- `ruff check .` (fails: SyntaxError and lint errors)
- `pytest` (fails: IndentationError in tests)


------
https://chatgpt.com/codex/tasks/task_e_689d7212a224832885fb0f4526367d65