### PR TITLE
Use dummy OpenAI key for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
           pip install -r requirements.txt
       - name: Run tests
         env:
+          # Provide a dummy key to ensure no real network calls are made
           OPENAI_API_KEY: dummy
         run: |
           pytest -q


### PR DESCRIPTION
## Summary
- Ensure tests run with a dummy `OPENAI_API_KEY`

## Testing
- `pytest -q` *(fails: IndentationError in chatgpt_client.py and test_watcher.py)*

------
https://chatgpt.com/codex/tasks/task_e_689d7214412883288c0e962e39bc98cc