### PR TITLE
test: verify caching in ChatGPTClient

### DIFF
--- a/tests/test_chatgpt_client.py
+++ b/tests/test_chatgpt_client.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from quiz_automation.chatgpt_client import ChatGPTClient
+from quiz_automation.chatgpt_client import ChatGPTClient, ChatGPTResponse
 
 
 class DummyResponses:
@@ -139,5 +139,13 @@ def test_chatgpt_client_uses_cache(monkeypatch):
 
     client = ChatGPTClient()
 
+    first = client.ask("question")
     assert counting.calls == 1
+    assert isinstance(first, ChatGPTResponse)
+    assert first.answer == "A"
+
+    second = client.ask("question")
+    assert counting.calls == 1
+    assert isinstance(second, ChatGPTResponse)
+    assert second.answer == "A"
 


### PR DESCRIPTION
## Summary
- extend caching test to exercise `ChatGPTClient.ask` twice and verify result type

## Testing
- `pytest -q` *(fails: IndentationError in quiz_automation/chatgpt_client.py and SyntaxError in quiz_automation/config.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e6efc42c8328af33c84a7dab6320