### PR TITLE
Add headless CLI for quiz automation

### DIFF
--- a/quiz_automation/cli.py
+++ b/quiz_automation/cli.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Tuple
+
+from .chatgpt_client import ChatGPTClient, ChatGPTResponse
+from .config import get_settings
+from .logger import QuizLogger
+from .watcher import Watcher
+
+
+RegionTuple = Tuple[int, int, int, int]
+
+
+def _load_region(args: argparse.Namespace) -> RegionTuple:
+    if args.region:
+        return tuple(args.region)  # type: ignore[return-value]
+    if args.config:
+        data = json.loads(Path(args.config).read_text())
+        if isinstance(data, dict):
+            data = data.get("region", [])
+        if not (isinstance(data, Iterable) and len(data) == 4):
+            raise SystemExit("Invalid config file")
+        return tuple(int(x) for x in data)  # type: ignore[return-value]
+    raise SystemExit("Region not specified. Use --region or --config")
+
+
+def run_headless(argv: list[str] | None = None) -> None:
+    """Run quiz automation without a GUI."""
+
+    parser = argparse.ArgumentParser(description="Headless quiz automation")
+    parser.add_argument(
+        "--region",
+        nargs=4,
+        type=int,
+        metavar=("LEFT", "TOP", "WIDTH", "HEIGHT"),
+        help="Capture region coordinates",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        help="Path to JSON file containing region coordinates",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=Path("events.db"),
+        help="Path to SQLite log database",
+    )
+    args = parser.parse_args(argv)
+
+    region = _load_region(args)
+    settings = get_settings()
+    client = ChatGPTClient()
+    logger = QuizLogger(args.db)
+
+    def on_question(text: str) -> None:
+        resp: ChatGPTResponse = client.ask(text)
+        print(f"{text} -> {resp.answer}")
+        ts = datetime.now().isoformat()
+        input_tokens = getattr(resp.usage, "input_tokens", 0)
+        output_tokens = getattr(resp.usage, "output_tokens", 0)
+        logger.log(
+            ts,
+            text,
+            resp.answer,
+            0,
+            0,
+            input_tokens,
+            output_tokens,
+            resp.cost,
+        )
+
+    watcher = Watcher(
+        region,
+        on_question,
+        settings.poll_interval,
+        screenshot_dir=settings.screenshot_dir,
+    )
+    watcher.start()
+
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        watcher.stop_flag.set()
+        watcher.join()
+        logger.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+from threading import Event, Thread
+from pathlib import Path
+import json
+import time
+
+from quiz_automation.chatgpt_client import ChatGPTResponse
+import quiz_automation.cli as cli
+
+
+class DummyWatcher(Thread):
+    def __init__(self, region, on_question, poll_interval, **kwargs):
+        super().__init__(daemon=True)
+        self.region = region
+        self.on_question = on_question
+        self.stop_flag = Event()
+
+    def run(self) -> None:
+        self.on_question("What is 2+2?")
+
+
+class DummyClient:
+    def ask(self, question: str) -> ChatGPTResponse:
+        usage = SimpleNamespace(input_tokens=1, output_tokens=1)
+        return ChatGPTResponse("A", usage, 0.0)
+
+
+class DummyLogger:
+    def __init__(self, path: Path):
+        self.closed = False
+        LOGGERS.append(self)
+
+    def log(self, *args, **kwargs):
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+LOGGERS: list[DummyLogger] = []
+
+
+def _setup(monkeypatch):
+    monkeypatch.setattr(cli, "Watcher", DummyWatcher)
+    monkeypatch.setattr(cli, "ChatGPTClient", lambda: DummyClient())
+    monkeypatch.setattr(cli, "QuizLogger", DummyLogger)
+    monkeypatch.setattr(
+        cli, "get_settings", lambda: SimpleNamespace(poll_interval=0.1, screenshot_dir=None)
+    )
+    real_sleep = time.sleep
+
+    def fake_sleep(_):
+        real_sleep(0.01)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli.time, "sleep", fake_sleep)
+
+
+def test_run_headless_with_region(monkeypatch, capsys):
+    _setup(monkeypatch)
+    cli.run_headless(["--region", "0", "0", "1", "1"])
+    out = capsys.readouterr().out.strip()
+    assert out == "What is 2+2? -> A"
+    assert LOGGERS and LOGGERS[0].closed
+
+
+def test_run_headless_with_config(monkeypatch, capsys, tmp_path):
+    _setup(monkeypatch)
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps([0, 0, 1, 1]))
+    cli.run_headless(["--config", str(cfg)])
+    out = capsys.readouterr().out.strip()
+    assert out == "What is 2+2? -> A"
+    assert LOGGERS and LOGGERS[-1].closed


### PR DESCRIPTION
## Summary
- add `run_headless` CLI entry that accepts region via args or JSON config
- log questions and answers while printing `question -> answer`
- ensure clean shutdown on `KeyboardInterrupt`
- test CLI with mocked watcher and client

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2f67b56448328bc1c412c0e088ff3