### PR TITLE
Display running API cost in quiz GUI

### DIFF
--- a/quiz_automation/logger.py
+++ b/quiz_automation/logger.py
@@ -38,7 +38,7 @@ class QuizLogger:
         input_tokens: int,
         output_tokens: int,
         cost: float,
-    ) -> None:
+    ) -> float:
         self.conn.execute(
             """
             INSERT INTO events (
@@ -48,6 +48,7 @@ class QuizLogger:
             (ts, question, answer, x, y, input_tokens, output_tokens, cost),
         )
         self.conn.commit()
+        return cost
 
     def close(self) -> None:
         """Close the underlying SQLite connection."""

--- a/tests/test_gui_integration.py
+++ b/tests/test_gui_integration.py
@@ -27,6 +27,7 @@ def test_on_question_flow(monkeypatch):
 
         def log(self, ts, question, answer, x, y, in_toks, out_toks, cost):
             calls['log'] = (ts, question, answer, x, y, in_toks, out_toks, cost)
+            return cost
 
         def close(self):
             calls['closed'] = True
@@ -106,6 +107,9 @@ def test_on_question_flow(monkeypatch):
     assert calls['log'][5] == 1
     assert calls['log'][6] == 2
     assert calls['log'][7] == 0.5
+
+    assert gui.total_cost == 0.5
+    assert gui.status_var.get() == "Running – $0.50"
 
     gui.shutdown()
     assert calls['closed'] is True


### PR DESCRIPTION
## Summary
- Track cumulative API cost in `QuizGUI`
- Expose cost from `QuizLogger.log`
- Test GUI integration reports running cost

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2f67addac8328b83759757e8578f7