### PR TITLE
chore: remove pytest from watcher tests

### DIFF
--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,3 +1,6 @@
+from threading import Event
+from PIL import Image
+
 from quiz_automation.watcher import Watcher
 
 
@@ -7,12 +10,6 @@ def test_watcher_initialization():
     region = (0, 0, 1, 1)
     w = Watcher(region, lambda _: None, capture=lambda r: None, ocr=lambda i: "")
     assert w.region == region
-=======
-from threading import Event
-from PIL import Image
-import pytest
-
-from quiz_automation.watcher import Watcher
 
 
 def test_is_new_question() -> None:


### PR DESCRIPTION
## Summary
- clean up watcher test imports
- drop unused pytest import

## Testing
- `ruff check tests/test_watcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3aea41b448328b7e94b14d6f3aa04